### PR TITLE
Changes to SuperHeavy Cluster configs

### DIFF
--- a/GameData/StarshipExpansionProject/Parts/SH_21_Cluster.cfg
+++ b/GameData/StarshipExpansionProject/Parts/SH_21_Cluster.cfg
@@ -53,9 +53,10 @@ PART
 	
 	MODULE
 	{
-		name = MultiModeEngine
-		primaryEngineID = AllEngines
-		secondaryEngineID = MidInner
+       name = ModuleTundraEngineSwitch
+       primaryEngineID = AllEngines
+       secondaryEngineID = MiddleInner
+       tertiaryEngineID = CenterThree
 	}
 	MODULE
 	{
@@ -66,8 +67,8 @@ PART
 		exhaustDamage = True
 		ignitionThreshold = 0.1
 		minThrust = 0
-		maxThrust = 17280
-		heatProduction = 864
+		maxThrust = 18560
+		heatProduction = 640
 		EngineType = LiquidFuel
 		PROPELLANT
 		{
@@ -90,14 +91,44 @@ PART
 	MODULE
 	{
 		name = ModuleEnginesFX
-		engineID = MidInner
-		runningEffectName = running_one
+		engineID = MiddleInner
+		runningEffectName = running_twelve
 		thrustVectorTransformName = middlethrusttransform
 		exhaustDamage = True
 		ignitionThreshold = 0.1
 		minThrust = 0
-		maxThrust = 6480
+		maxThrust = 6960
 		heatProduction = 240
+		EngineType = LiquidFuel
+		PROPELLANT
+		{
+			name = LiquidFuel
+			ratio = 0.9
+			DrawGauge = True
+		}
+		PROPELLANT
+		{
+			name = Oxidizer
+			ratio = 1.1
+		}
+		atmosphereCurve
+		{
+			key = 0 330
+			key = 1 303.6
+			key = 12 0.001
+		}
+	}
+	MODULE
+	{
+		name = ModuleEnginesFX
+		engineID = CenterThree
+		runningEffectName = running_three
+		thrustVectorTransformName = innerthrusttransform
+		exhaustDamage = True
+		ignitionThreshold = 0.1
+		minThrust = 0
+		maxThrust = 1740
+		heatProduction = 60
 		EngineType = LiquidFuel
 		PROPELLANT
 		{
@@ -135,13 +166,22 @@ PART
 		maxDistance = 40
 		falloff = 1.8
 		thrustTransformName = middlethrusttransform
+	}
+MODULE
+	{
+		name = ModuleSurfaceFX
+		thrustProviderModuleIndex = 3
+		fxMax = 0.4
+		maxDistance = 22
+		falloff = 1.8
+		thrustTransformName = innerthrusttransform
 	}	
 
 	MODULE
 	{
 		name = ModuleGimbal
 		gimbalTransformName = gimbal
-		gimbalRange = 15
+		gimbalRange = 7.5
 		useGimbalResponseSpeed = true
 		gimbalResponseSpeed = 10
 	}

--- a/GameData/StarshipExpansionProject/Patches/Waterfall/SH cluster.cfg
+++ b/GameData/StarshipExpansionProject/Patches/Waterfall/SH cluster.cfg
@@ -17,20 +17,34 @@
 				loop = true
 			}
     }
-	      running_one
+	running_twelve
+	{
+		AUDIO
 		{
-			AUDIO
-			{
-				channel = Ship
-				clip = Waterfall/Sounds/ZorgSounds/loop_raptor_sealevel
-				volume = 0.0 0.0
-				volume = 0.1 0.3
-				volume = 1.0 1.0
-				pitch = 0.0 0.7
-				pitch = 1.0 1.0
-				loop = true
-			}
+			channel = Ship
+			clip = Waterfall/Sounds/ZorgSounds/loop_raptor_sealevel
+			volume = 0.0 0.0
+			volume = 0.1 0.3
+			volume = 1.0 1.0
+			pitch = 0.0 0.7
+			pitch = 1.0 1.0
+			loop = true
 		}
+	}
+	running_three
+	{
+		AUDIO
+		{
+			channel = Ship
+			clip = Waterfall/Sounds/ZorgSounds/loop_raptor_sealevel
+			volume = 0.0 0.0
+			volume = 0.1 0.3
+			volume = 1.0 1.0
+			pitch = 0.0 0.7
+			pitch = 1.0 1.0
+			loop = true
+		}
+	}
     engage
     {
       AUDIO
@@ -110,7 +124,7 @@
     // This is a custom name
     moduleID = raptorclusterMiddle
     // This links the effects to a given ModuleEngines
-    engineID = MidInner
+    engineID = MiddleInner
 
     // List out all controllers we want available
     // This controller scales with atmosphere depth
@@ -124,7 +138,7 @@
     {
       name = throttle
       linkedTo = throttle
-	  engineID = MidInner
+	  engineID = MiddleInner
     }
     // this controller generates a random value in the range specified
     CONTROLLER
@@ -142,6 +156,50 @@
       templateName = waterfall-methalox-lower-raptor-1
       // This field allows you to override the parentTransform name in the EFFECTS contained in the template
       overrideParentTransform = middlethrusttransform
+		position = 0, 0, 0
+		rotation = 0, 0, 0
+		scale = 0.7,0.7,0.7
+    }
+
+  }
+	MODULE
+	{
+    name = ModuleWaterfallFX
+    // This is a custom name
+    moduleID = raptorclusterInner
+    // This links the effects to a given ModuleEngines
+    engineID = CenterThree
+
+    // List out all controllers we want available
+    // This controller scales with atmosphere depth
+    CONTROLLER
+    {
+      name = atmosphereDepth
+      linkedTo = atmosphere_density
+    }
+    // This controller scales with effective throttle
+    CONTROLLER
+    {
+      name = throttle
+      linkedTo = throttle
+	  engineID = CenterThree
+    }
+    // this controller generates a random value in the range specified
+    CONTROLLER
+    {
+      name = random
+      linkedTo = random
+      range = -1,1
+    }
+    // -----------------------------------------------------
+    // Past here should be generated with the ingame editor!
+    // -----------------------------------------------------
+    TEMPLATE
+    {
+      // This is the name of the template to use
+      templateName = waterfall-methalox-lower-raptor-1
+      // This field allows you to override the parentTransform name in the EFFECTS contained in the template
+      overrideParentTransform = innerthrusttransform
 		position = 0, 0, 0
 		rotation = 0, 0, 0
 		scale = 0.7,0.7,0.7


### PR DESCRIPTION
Added a third engine plume to the waterfall config.
Tweaked engine power to be in line with the CryoEngines patch in Extras.
Decreased gimbal range from 15 either side to 15 total.
Added a ThreeEngine mode to the SuperHeavy engine cluster.
