### PR TITLE
Fix Header Description

### DIFF
--- a/Extras/RO-RP1/StarshipRO.cfg
+++ b/Extras/RO-RP1/StarshipRO.cfg
@@ -318,7 +318,7 @@
 {
 	@mass = 2
 	@title = Starship Header Tank
-	@description = This Module carry fuel for your refueling missions. Probably will be your most used module.
+	@description = This small tank sits perfectly on the nose. A perfect source of fuel for landing burns.
 	
 	MODULE
 	{


### PR DESCRIPTION
Header Tank description was a copy-paste of the tanker nose description.