### PR TITLE
Add hotstage ring to RP-1 tech tree

### DIFF
--- a/Extras/RO-RP1/SuperHeavyRP1.cfg
+++ b/Extras/RO-RP1/SuperHeavyRP1.cfg
@@ -63,3 +63,15 @@
 	MODULE
 	{ name = ModuleTagNoResourceCostMult }
 }
+@PART[SEP_23_BOOSTER_HSR]:FOR[xxxRP0]
+{
+	%TechRequired = orbitalRocketryNF
+	%cost = 2000
+	%entryCost = 0
+	%RP0conf = true
+
+	MODULE
+	{ name = ModuleTagHumanRated }
+	MODULE
+	{ name = ModuleTagNoResourceCostMult }
+}


### PR DESCRIPTION
Fix bug where hotstage ring doesn't appear on RP-1 by adding the HSR to the tech tree