### PR TITLE
Add kOS processor support for Donnager and Behemoth parts

### DIFF
--- a/GameData/StarshipExpansionProject/Patches/kOS.cfg
+++ b/GameData/StarshipExpansionProject/Patches/kOS.cfg
@@ -1,0 +1,24 @@
+// kOS Support for Starship Expansion Project
+// Adds kOS processors to command-capable parts when kOS is installed.
+// Nose/upper parts get their own processor so they can run scripts
+// independently after stage separation.
+
+// Body/Core parts - larger disk space for main flight scripts
+@PART[SEP_24_HOPPY|SEP_24_SHIP_PROTO_BODY|SEP_24_SHIP_CORE|SEP_24_SHIP_CORE_EXP|SEP_25_BOOSTER_CORE|SEP_25_SHIP_CORE]:NEEDS[kOS]:AFTER[StarshipExpansionProject]
+{
+	MODULE
+	{
+		name = kOSProcessor
+		diskSpace = 200000
+	}
+}
+
+// Nose/Upper/Cargo parts - separate processor for post-separation control
+@PART[SEP_24_SHIP_PROTO_NOSE|SEP_24_SHIP_NOSECONE|SEP_24_SHIP_NOSECONE_EXP|SEP_24_SHIP_CARGO|SEP_24_SHIP_CARGO_EXP|SEP_24_SHIP_PEZ|SEP_24_SHIP_PEZ_EXP|SEP_25_SHIP_PEZ|SEP_25_SHIP_CARGO]:NEEDS[kOS]:AFTER[StarshipExpansionProject]
+{
+	MODULE
+	{
+		name = kOSProcessor
+		diskSpace = 200000
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a Module Manager patch (`Patches/kOS.cfg`) that conditionally adds kOS flight computer processors to all command-capable Donnager and Behemoth parts when [kOS](https://github.com/KSP-KOS/KOS) is installed
- Body/core parts and nose/upper/cargo parts each get their own processor, enabling independent kOS script execution after stage separation
- Uses `:NEEDS[kOS]:AFTER[StarshipExpansionProject]` to ensure the patch only applies when kOS is present and loads after SEP parts are defined

## Parts covered

**Bodies/Cores** (main flight computer):
- `SEP_24_HOPPY` — Donnager Suborbital Hopper
- `SEP_24_SHIP_PROTO_BODY` — Donnager Suborbital Main Body
- `SEP_24_SHIP_CORE` — Donnager BL-1 Main Body
- `SEP_24_SHIP_CORE_EXP` — Donnager BL-1 Expendable Main Body
- `SEP_25_BOOSTER_CORE` — Behemoth BL-1 Core
- `SEP_25_SHIP_CORE` — Donnager BL-2 Main Body

**Nose/Upper/Cargo** (independent control after separation):
- `SEP_24_SHIP_PROTO_NOSE` — Donnager Suborbital Nose Module
- `SEP_24_SHIP_NOSECONE` / `_EXP` — Donnager BL-1 Nosecone
- `SEP_24_SHIP_CARGO` / `_EXP` — Donnager BL-1 Cargo Module
- `SEP_24_SHIP_PEZ` / `_EXP` — Donnager BL-1 Pez Module
- `SEP_25_SHIP_PEZ` — Donnager BL-2 Pez Module
- `SEP_25_SHIP_CARGO` — Donnager BL-2 Cargo Module

## Why this is useful
kOS is one of the most popular autopilot/scripting mods for KSP. Adding native processor support means users can write and run flight scripts (launch, landing, boostback, belly flop maneuvers, etc.) on SEP vehicles without needing to create their own Module Manager patches. The separate processor on nose parts is important because after stage separation, the upper stage needs its own kOS computer to continue running scripts independently.

## Test plan
- [x] Verified all part names match current SEP part configs
- [x] Skipped deprecated parts (`SEP_24_SHIP_HEADER`)
- [ ] Load KSP with SEP + kOS installed, verify processors appear in VAB on all listed parts
- [ ] Build full stack, verify both body and nose have independent kOS terminals
- [ ] Stage separate, verify both halves can run scripts independently